### PR TITLE
draft base contract and interfaces

### DIFF
--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -1,3 +1,3 @@
-@openzeppelin/contracts@4.8.1/=lib/teleporter/contracts/lib/openzeppelin-contracts/
-@avalabs/subnet-evm-contracts@1.2.0/=lib/teleporter/contracts/lib/subnet-evm/
+@openzeppelin/contracts@4.8.1/=lib/teleporter/contracts/lib/openzeppelin-contracts/contracts/
+@avalabs/subnet-evm-contracts@1.2.0/=lib/teleporter/contracts/lib/subnet-evm/contracts/
 @teleporter/=lib/teleporter/contracts/src/Teleporter/

--- a/contracts/src/TeleporterTokenDestination.sol
+++ b/contracts/src/TeleporterTokenDestination.sol
@@ -24,9 +24,6 @@ abstract contract TeleporterTokenDestination is
     ITeleporterTokenBridge,
     TeleporterOwnerUpgradeable
 {
-    // Warp precompile used for sending and receiving Warp messages.
-    address public constant WARP_PRECOMPILE_ADDRESS = 0x0200000000000000000000000000000000000005;
-
     // The blockchain ID of the chain this contract is deployed on.
     bytes32 public immutable blockchainID;
 
@@ -54,7 +51,7 @@ abstract contract TeleporterTokenDestination is
         // NativeTokenDestination will pass in erc20 token it deposits native tokens to pay for fees.
         // ERC20Destination will pass in the erc20 token it's bridging.
         feeToken = IERC20(feeToken_);
-        blockchainID = IWarpMessenger(WARP_PRECOMPILE_ADDRESS).getBlockchainID();
+        blockchainID = IWarpMessenger(0x0200000000000000000000000000000000000005).getBlockchainID();
     }
 
     /**

--- a/contracts/src/TeleporterTokenDestination.sol
+++ b/contracts/src/TeleporterTokenDestination.sol
@@ -1,0 +1,161 @@
+// (c) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.18;
+
+import {TeleporterMessageInput, TeleporterFeeInfo} from "@teleporter/ITeleporterMessenger.sol";
+import {TeleporterOwnerUpgradeable} from "@teleporter/upgrades/TeleporterOwnerUpgradeable.sol";
+import {ITeleporterTokenBridge} from "./interfaces/ITeleporterTokenBridge.sol";
+import {IWarpMessenger} from
+    "@avalabs/subnet-evm-contracts@1.2.0/contracts/interfaces/IWarpMessenger.sol";
+import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/IERC20.sol";
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+
+/**
+ * @dev Abstract contract for a Teleporter token bridge that receives tokens from a {TeleporterTokenSource} in exchange for the tokens of this token bridge instance.
+ */
+abstract contract TeleporterTokenDestination is
+    ITeleporterTokenBridge,
+    TeleporterOwnerUpgradeable
+{
+    // Warp precompile used for sending and receiving Warp messages.
+    address public constant WARP_PRECOMPILE_ADDRESS = 0x0200000000000000000000000000000000000005;
+
+    // The blockchain ID of the chain this contract is deployed on.
+    bytes32 public immutable blockchainID;
+
+    // The blockchain ID of the source chain this contract receives tokens from.
+    bytes32 public immutable sourceBlockchainID;
+    // The address of the source token bridge instance this contract receives tokens from.
+    address public immutable tokenSourceAddress;
+    // The ERC20 token this contract uses to pay for Teleporter fees.
+    IERC20 public immutable feeToken;
+
+    /**
+     * @dev Initializes this destination token bridge instance to receive
+     * tokens from the specified source blockchain and token bridge instance.
+     */
+    constructor(
+        address teleporterRegistryAddress,
+        address teleporterManager,
+        bytes32 sourceBlockchainID_,
+        address tokenSourceAddress_,
+        address feeToken_
+    ) TeleporterOwnerUpgradeable(teleporterRegistryAddress, teleporterManager) {
+        sourceBlockchainID = sourceBlockchainID_;
+        tokenSourceAddress = tokenSourceAddress_;
+        // TODO: figure out if NativeTokenDestination passes in token or not.
+        // NativeTokenDestination will pass in erc20 token it deposits native tokens to pay for fees.
+        // ERC20Destination will pass in the erc20 token it's bridging.
+        feeToken = IERC20(feeToken_);
+        blockchainID = IWarpMessenger(WARP_PRECOMPILE_ADDRESS).getBlockchainID();
+    }
+
+    /**
+     * @dev Sends tokens transferred to this contract to the destination token bridge instance.
+     *
+     * Burns the bridged amount, and uses Teleporter to send a cross chain message.
+     * TODO: Determine if this can be abstracted to a common function with {TeleporterTokenSource}
+     * Requirements:
+     *
+     * - `input.destinationBlockchainID` cannot be the same as the current blockchainID
+     * - `input.destinationBridgeAddress` cannot be the zero address
+     * - `input.recipient` cannot be the zero address
+     * - `amount` must be greater than 0
+     * - `amount` must be greater than `input.primaryFee`
+     */
+    function _send(SendTokensInput calldata input, uint256 amount) internal virtual {
+        require(
+            input.destinationBlockchainID != blockchainID,
+            "TeleporterTokenDestination: cannot bridge to same chain"
+        );
+        require(
+            input.destinationBridgeAddress != address(0),
+            "TeleporterTokenDestination: zero destination bridge address"
+        );
+        require(input.recipient != address(0), "TeleporterTokenDestination: zero recipient address");
+        require(amount > 0, "TeleporterTokenDestination: zero send amount");
+        require(
+            amount > input.primaryFee,
+            "TeleporterTokenDestination: insufficient amount to cover fees"
+        );
+
+        // TODO: For NativeTokenDestination before this _send, we should exchange the fee amount
+        // in native tokens for the fee amount in erc20 tokens. For ERC20Destination, we simply
+        // safeTransferFrom the full amount.
+        amount -= input.primaryFee;
+        _burn(amount);
+
+        bytes32 messageID = _sendTeleporterMessage(
+            TeleporterMessageInput({
+                destinationBlockchainID: sourceBlockchainID,
+                destinationAddress: tokenSourceAddress,
+                feeInfo: TeleporterFeeInfo({
+                    feeTokenAddress: address(feeToken),
+                    amount: input.primaryFee
+                }),
+                // TODO: placeholder value
+                requiredGasLimit: 0,
+                allowedRelayerAddresses: input.allowedRelayerAddresses,
+                message: abi.encode(
+                    SendTokensInput({
+                        destinationBlockchainID: input.destinationBlockchainID,
+                        destinationBridgeAddress: input.destinationBridgeAddress,
+                        recipient: input.recipient,
+                        primaryFee: input.secondaryFee,
+                        secondaryFee: 0,
+                        // TODO: Does multihop allowed relayer need to be separate parameter?
+                        allowedRelayerAddresses: input.allowedRelayerAddresses
+                    }),
+                    amount
+                    )
+            })
+        );
+
+        emit SendTokens(messageID, msg.sender, amount);
+    }
+
+    /**
+     * @dev See {ITeleporterUpgradeable-_receiveTeleporterMessage}
+     *
+     * Verifies the source token bridge instance, and withdraws the amount to the recipient address.
+     */
+    function _receiveTeleporterMessage(
+        bytes32 sourceBlockchainID_,
+        address originSenderAddress,
+        bytes memory message
+    ) internal virtual override {
+        require(
+            sourceBlockchainID_ == sourceBlockchainID,
+            "TeleporterTokenDestination: invalid source chain"
+        );
+        require(
+            originSenderAddress == tokenSourceAddress,
+            "TeleporterTokenDestination: invalid token source address"
+        );
+        (address recipient, uint256 amount) = abi.decode(message, (address, uint256));
+
+        _withdraw(recipient, amount);
+    }
+
+    /**
+     * @dev Burns tokens from the sender's balance.
+     * @param amount The amount of tokens to burn
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _burn(uint256 amount) internal virtual;
+
+    /**
+     * @dev Withdraws tokens to the recipient address.
+     * @param recipient The address to withdraw tokens to
+     * @param amount The amount of tokens to withdraw
+     */
+    // solhint-disable-next-line no-empty-blocks
+    function _withdraw(address recipient, uint256 amount) internal virtual;
+}

--- a/contracts/src/TeleporterTokenDestination.sol
+++ b/contracts/src/TeleporterTokenDestination.sol
@@ -18,24 +18,25 @@ import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/IERC20.sol";
  */
 
 /**
+ * @title TeleporterTokenDestination
  * @dev Abstract contract for a Teleporter token bridge that receives tokens from a {TeleporterTokenSource} in exchange for the tokens of this token bridge instance.
  */
 abstract contract TeleporterTokenDestination is
     ITeleporterTokenBridge,
     TeleporterOwnerUpgradeable
 {
-    // The blockchain ID of the chain this contract is deployed on.
+    /// @notice The blockchain ID of the chain this contract is deployed on.
     bytes32 public immutable blockchainID;
 
-    // The blockchain ID of the source chain this contract receives tokens from.
+    /// @notice The blockchain ID of the source chain this contract receives tokens from.
     bytes32 public immutable sourceBlockchainID;
-    // The address of the source token bridge instance this contract receives tokens from.
+    /// @notice The address of the source token bridge instance this contract receives tokens from.
     address public immutable tokenSourceAddress;
-    // The ERC20 token this contract uses to pay for Teleporter fees.
+    /// @notice The ERC20 token this contract uses to pay for Teleporter fees.
     IERC20 public immutable feeToken;
 
     /**
-     * @dev Initializes this destination token bridge instance to receive
+     * @notice Initializes this destination token bridge instance to receive
      * tokens from the specified source blockchain and token bridge instance.
      */
     constructor(
@@ -55,9 +56,9 @@ abstract contract TeleporterTokenDestination is
     }
 
     /**
-     * @dev Sends tokens transferred to this contract to the destination token bridge instance.
+     * @notice Sends tokens to the specified destination token bridge instance.
      *
-     * Burns the bridged amount, and uses Teleporter to send a cross chain message.
+     * @dev Burns the bridged amount, and uses Teleporter to send a cross chain message.
      * TODO: Determine if this can be abstracted to a common function with {TeleporterTokenSource}
      * Requirements:
      *
@@ -119,9 +120,9 @@ abstract contract TeleporterTokenDestination is
     }
 
     /**
-     * @dev See {ITeleporterUpgradeable-_receiveTeleporterMessage}
+     * @notice Verifies the source token bridge instance, and withdraws the amount to the recipient address.
      *
-     * Verifies the source token bridge instance, and withdraws the amount to the recipient address.
+     * @dev See {ITeleporterUpgradeable-_receiveTeleporterMessage}
      */
     function _receiveTeleporterMessage(
         bytes32 sourceBlockchainID_,
@@ -142,14 +143,14 @@ abstract contract TeleporterTokenDestination is
     }
 
     /**
-     * @dev Burns tokens from the sender's balance.
+     * @notice Burns tokens from the sender's balance.
      * @param amount The amount of tokens to burn
      */
     // solhint-disable-next-line no-empty-blocks
     function _burn(uint256 amount) internal virtual;
 
     /**
-     * @dev Withdraws tokens to the recipient address.
+     * @notice Withdraws tokens to the recipient address.
      * @param recipient The address to withdraw tokens to
      * @param amount The amount of tokens to withdraw
      */

--- a/contracts/src/TeleporterTokenSource.sol
+++ b/contracts/src/TeleporterTokenSource.sol
@@ -18,28 +18,31 @@ import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/IERC20.sol";
  */
 
 /**
+ * @title TeleporterTokenSource
  * @dev Abstract contract for a Teleporter token bridge that sends tokens to {TeleporterTokenDestination} instances.
  *
  * This contract also handles multihop transfers, where tokens sent from a {TeleporterTokenDestination}
  * instance are forwarded to another {TeleporterTokenDestination} instance.
  */
 abstract contract TeleporterTokenSource is ITeleporterTokenBridge, TeleporterOwnerUpgradeable {
-    // The blockchain ID of the chain this contract is deployed on.
+    /// @notice The blockchain ID of the chain this contract is deployed on.
     bytes32 public immutable blockchainID;
 
-    // The ERC20 token this contract uses to pay for Teleporter fees.
+    /// @notice The ERC20 token this contract uses to pay for Teleporter fees.
     IERC20 public immutable feeToken;
 
-    // Tracks the balances of tokens sent to other bridge instances.
-    // Bridges are not allowed to unwrap more than has been sent to them.
-    // (destinationBlockchainID, destinationBridgeAddress) -> balance
+    /**
+     * @notice Tracks the balances of tokens sent to other bridge instances.
+     * Bridges are not allowed to unwrap more than has been sent to them.
+     * @dev (destinationBlockchainID, destinationBridgeAddress) -> balance
+     */
     mapping(
         bytes32 destinationBlockchainID
             => mapping(address destinationBridgeAddress => uint256 balance)
     ) public bridgedBalances;
 
     /**
-     * @dev Initializes this source token bridge instance to send
+     * @notice Initializes this source token bridge instance to send
      * tokens to the specified destination chain and token bridge instance.
      */
     constructor(
@@ -52,9 +55,9 @@ abstract contract TeleporterTokenSource is ITeleporterTokenBridge, TeleporterOwn
     }
 
     /**
-     * @dev Sends tokens transferred to this contract to the destination token bridge instance.
+     * @notice Sends tokens to the specified destination token bridge instance.
      *
-     * Increases the bridge balance sent to each destination token bridge instance,
+     * @dev Increases the bridge balance sent to each destination token bridge instance,
      * and uses Teleporter to send a cross chain message.
      * TODO: Determine if this can be abstracted to a common function with {TeleporterTokenDestination}
      * Requirements:

--- a/contracts/src/TeleporterTokenSource.sol
+++ b/contracts/src/TeleporterTokenSource.sol
@@ -1,0 +1,138 @@
+// (c) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.18;
+
+import {TeleporterMessageInput, TeleporterFeeInfo} from "@teleporter/ITeleporterMessenger.sol";
+import {TeleporterOwnerUpgradeable} from "@teleporter/upgrades/TeleporterOwnerUpgradeable.sol";
+import {ITeleporterTokenBridge} from "./interfaces/ITeleporterTokenBridge.sol";
+import {IWarpMessenger} from
+    "@avalabs/subnet-evm-contracts@1.2.0/contracts/interfaces/IWarpMessenger.sol";
+import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/IERC20.sol";
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+
+/**
+ * @dev Abstract contract for a Teleporter token bridge that sends tokens to {TeleporterTokenDestination} instances.
+ *
+ * This contract also handles multihop transfers, where tokens sent from a {TeleporterTokenDestination}
+ * instance are forwarded to another {TeleporterTokenDestination} instance.
+ */
+abstract contract TeleporterTokenSource is ITeleporterTokenBridge, TeleporterOwnerUpgradeable {
+    // Warp precompile used for sending and receiving Warp messages.
+    address public constant WARP_PRECOMPILE_ADDRESS = 0x0200000000000000000000000000000000000005;
+
+    // The blockchain ID of the chain this contract is deployed on.
+    bytes32 public immutable blockchainID;
+
+    // The ERC20 token this contract uses to pay for Teleporter fees.
+    IERC20 public immutable feeToken;
+
+    // Tracks the balances of tokens sent to other bridge instances.
+    // Bridges are not allowed to unwrap more than has been sent to them.
+    // (destinationBlockchainID, destinationBridgeAddress) -> balance
+    mapping(
+        bytes32 destinationBlockchainID
+            => mapping(address destinationBridgeAddress => uint256 balance)
+    ) public bridgedBalances;
+
+    /**
+     * @dev Initializes this source token bridge instance to send
+     * tokens to the specified destination chain and token bridge instance.
+     */
+    constructor(
+        address teleporterRegistryAddress,
+        address teleporterManager,
+        address feeToken_
+    ) TeleporterOwnerUpgradeable(teleporterRegistryAddress, teleporterManager) {
+        feeToken = IERC20(feeToken_);
+        blockchainID = IWarpMessenger(WARP_PRECOMPILE_ADDRESS).getBlockchainID();
+    }
+
+    /**
+     * @dev Sends tokens transferred to this contract to the destination token bridge instance.
+     *
+     * Increases the bridge balance sent to each destination token bridge instance,
+     * and uses Teleporter to send a cross chain message.
+     * TODO: Determine if this can be abstracted to a common function with {TeleporterTokenDestination}
+     * Requirements:
+     *
+     * - `input.destinationBlockchainID` cannot be the same as the current blockchainID
+     * - `input.destinationBridgeAddress` cannot be the zero address
+     * - `input.recipient` cannot be the zero address
+     * - `amount` must be greater than 0
+     * - `amount` must be greater than `input.primaryFee`
+     */
+    function _send(SendTokensInput memory input, uint256 amount) internal virtual {
+        require(
+            input.destinationBlockchainID != blockchainID,
+            "TeleporterTokenSource: cannot bridge to same chain"
+        );
+        require(
+            input.destinationBridgeAddress != address(0),
+            "TeleporterTokenSource: zero destination bridge address"
+        );
+        require(input.recipient != address(0), "TeleporterTokenSource: zero recipient address");
+        require(amount > 0, "TeleporterTokenSource: zero send amount");
+        require(
+            amount > input.primaryFee, "TeleporterTokenSource: insufficient amount to cover fees"
+        );
+
+        // Subtract fee amount from amount and increase bridge balance
+        amount -= input.primaryFee;
+        bridgedBalances[input.destinationBlockchainID][input.destinationBridgeAddress] += amount;
+
+        // send message to destinationBridgeAddress
+        bytes32 messageID = _sendTeleporterMessage(
+            TeleporterMessageInput({
+                destinationBlockchainID: input.destinationBlockchainID,
+                destinationAddress: input.destinationBridgeAddress,
+                feeInfo: TeleporterFeeInfo({
+                    feeTokenAddress: address(feeToken),
+                    amount: input.primaryFee
+                }),
+                // TODO: Set requiredGasLimit
+                requiredGasLimit: 0,
+                allowedRelayerAddresses: input.allowedRelayerAddresses,
+                message: abi.encode(input.recipient, amount)
+            })
+        );
+
+        emit SendTokens(messageID, msg.sender, amount);
+    }
+
+    function _receiveTeleporterMessage(
+        bytes32 sourceBlockchainID,
+        address originSenderAddress,
+        bytes memory message
+    ) internal virtual override {
+        (SendTokensInput memory input, uint256 amount) =
+            abi.decode(message, (SendTokensInput, uint256));
+
+        // Check that bridge instance returning has sufficient amount in balance
+        uint256 senderBalance = bridgedBalances[sourceBlockchainID][originSenderAddress];
+        require(senderBalance >= amount, "TeleporterTokenSource: insufficient balance to unwrap");
+
+        // Decrement the bridge balance by the unwrap amount
+        bridgedBalances[sourceBlockchainID][originSenderAddress] = senderBalance - amount;
+
+        // decrement totalAmount from bridge balance
+        if (input.destinationBlockchainID == blockchainID) {
+            require(
+                input.destinationBridgeAddress == address(this),
+                "TeleporterTokenSource: invalid bridge address"
+            );
+            _withdraw(input.recipient, amount);
+        }
+
+        _send(input, amount);
+    }
+
+    // solhint-disable-next-line no-empty-blocks
+    function _withdraw(address recipient, uint256 amount) internal virtual;
+}

--- a/contracts/src/TeleporterTokenSource.sol
+++ b/contracts/src/TeleporterTokenSource.sol
@@ -24,9 +24,6 @@ import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/IERC20.sol";
  * instance are forwarded to another {TeleporterTokenDestination} instance.
  */
 abstract contract TeleporterTokenSource is ITeleporterTokenBridge, TeleporterOwnerUpgradeable {
-    // Warp precompile used for sending and receiving Warp messages.
-    address public constant WARP_PRECOMPILE_ADDRESS = 0x0200000000000000000000000000000000000005;
-
     // The blockchain ID of the chain this contract is deployed on.
     bytes32 public immutable blockchainID;
 
@@ -51,7 +48,7 @@ abstract contract TeleporterTokenSource is ITeleporterTokenBridge, TeleporterOwn
         address feeToken_
     ) TeleporterOwnerUpgradeable(teleporterRegistryAddress, teleporterManager) {
         feeToken = IERC20(feeToken_);
-        blockchainID = IWarpMessenger(WARP_PRECOMPILE_ADDRESS).getBlockchainID();
+        blockchainID = IWarpMessenger(0x0200000000000000000000000000000000000005).getBlockchainID();
     }
 
     /**

--- a/contracts/src/interfaces/IERC20Bridge.sol
+++ b/contracts/src/interfaces/IERC20Bridge.sol
@@ -1,0 +1,25 @@
+// (c) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.18;
+
+import {ITeleporterTokenBridge} from "./ITeleporterTokenBridge.sol";
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+
+/**
+ * @dev Interface for a Teleporter token bridge that sends ERC20 tokens to another chain.
+ */
+interface IERC20Bridge is ITeleporterTokenBridge {
+    /**
+     * @dev Sends ERC20 tokens transferred to this contract to the destination token bridge instance.
+     * @param input specifies information for delivery of the tokens
+     * @param amount amount of tokens to send
+     */
+    function send(SendTokensInput calldata input, uint256 amount) external;
+}

--- a/contracts/src/interfaces/INativeTokenBridge.sol
+++ b/contracts/src/interfaces/INativeTokenBridge.sol
@@ -1,0 +1,24 @@
+// (c) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.18;
+
+import {ITeleporterTokenBridge} from "./ITeleporterTokenBridge.sol";
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+
+/**
+ * @dev Interface for a Teleporter token bridge that sends native tokens to another chain.
+ */
+interface INativeTokenBridge is ITeleporterTokenBridge {
+    /**
+     * @dev Sends native tokens transferred to this contract to the destination token bridge instance.
+     * @param input specifies information for delivery of the tokens
+     */
+    function send(SendTokensInput calldata input) external payable;
+}

--- a/contracts/src/interfaces/ITeleporterTokenBridge.sol
+++ b/contracts/src/interfaces/ITeleporterTokenBridge.sol
@@ -1,0 +1,42 @@
+// (c) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.18;
+
+import {ITeleporterReceiver} from "@teleporter/ITeleporterReceiver.sol";
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+
+/**
+ * @dev Interface for a Teleporter token bridge that sends tokens to another chain.
+ */
+interface ITeleporterTokenBridge is ITeleporterReceiver {
+    /**
+     * @dev Parameters for delivery of tokens to another chain and destination recipient.
+     * @param destinationBlockchainID blockchainID of the destination
+     * @param destinationBridgeAddress address of the destination token bridge instance
+     * @param recipient address of the recipient on the destination chain
+     * @param primaryFee amount of tokens to pay for Teleporter fee on the source chain
+     * @param secondaryFee amount of tokens to pay for Teleporter fee if a multihop is needed.
+     * @param allowedRelayerAddresses addresses of relayers allowed to send the message
+     */
+    struct SendTokensInput {
+        bytes32 destinationBlockchainID;
+        address destinationBridgeAddress;
+        address recipient;
+        uint256 primaryFee;
+        uint256 secondaryFee;
+        address[] allowedRelayerAddresses;
+    }
+
+    /**
+     * @dev Emitted when tokens are sent to another chain.
+     * TODO: might want to add SendTokensInput as a parameter
+     */
+    event SendTokens(bytes32 indexed teleporterMessageID, address indexed sender, uint256 amount);
+}


### PR DESCRIPTION
## Why this should be merged
Implements the base contracts to be used by erc20/native token bridges. Fixes #4 #2 

## How this works
`TeleporterTokenSource` handles depositing user funds to the source bridge contract, and initiating the cross-chain messaging process of Teleporter. The source contract also keeps track of bridged balances as its deployed on home chain, and holds the user's original existing token funds. When receiving a Teleporter message, checks whether the sender has available bridge balance to bridge back, then do a multihop if its not the final destination, or release back the original funds if it is final destination.

`TeleporterTokenDestination` deposits user funds to a destination token bridge contract. The contract takes an amount and erc20 to pay for Teleporter fees, the rest of the tokens are burned, and then a cross-chain message is sent with Teleporter. When receiving a Teleporter message, verifies that the sender is the token source address, and withdraws corresponding tokens to the recipient.

## How this was tested
TODO #8 #9 

## How is this documented
README, natspec
