### PR TITLE
Erc20source and destination contracts

### DIFF
--- a/contracts/src/.solhint.json
+++ b/contracts/src/.solhint.json
@@ -1,35 +1,36 @@
 {
-    "extends": "solhint:recommended",
-    "rules": {
-        "compiler-version": ["error", "0.8.18"],
-        "no-unused-vars": "error",
-        "func-visibility": [
-            "error",
-            {
-                "ignoreConstructors": true
-            }
-        ],
-        "private-vars-leading-underscore": [
-            "warn",
-            {
-                "strict": true
-            }
-        ],
-        "reason-string": [
-            "warn",
-            {
-                "maxLength": 75
-            }
-        ],
-        "custom-errors": "off",
-        "ordering": "error",
-        "immutable-vars-naming": [
-            "warn",
-            {
-                "immutablesAsConstants": false
-            }
-        ],
-        "func-named-parameters": ["error", 5],
-        "one-contract-per-file": "off"
-    }
+  "extends": "solhint:recommended",
+  "rules": {
+    "compiler-version": ["error", "0.8.18"],
+    "no-unused-vars": "error",
+    "func-visibility": [
+      "error",
+      {
+        "ignoreConstructors": true
+      }
+    ],
+    "private-vars-leading-underscore": [
+      "warn",
+      {
+        "strict": true
+      }
+    ],
+    "reason-string": [
+      "warn",
+      {
+        "maxLength": 75
+      }
+    ],
+    "custom-errors": "off",
+    "ordering": "error",
+    "immutable-vars-naming": [
+      "warn",
+      {
+        "immutablesAsConstants": false
+      }
+    ],
+    "func-named-parameters": ["error", 5],
+    "one-contract-per-file": "off",
+    "no-empty-blocks": "off"
+  }
 }

--- a/contracts/src/ERC20Destination.sol
+++ b/contracts/src/ERC20Destination.sol
@@ -1,0 +1,98 @@
+// (c) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.18;
+
+import {TeleporterTokenDestination} from "./TeleporterTokenDestination.sol";
+import {IERC20Bridge} from "./interfaces/IERC20Bridge.sol";
+import {SafeERC20TransferFrom} from "@teleporter/SafeERC20TransferFrom.sol";
+import {IERC20, ERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/utils/SafeERC20.sol";
+import {SendTokensInput} from "./interfaces/ITeleporterTokenBridge.sol";
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+
+/**
+ * @title ERC20Destination
+ * @notice This contract is an {IERC20Bridge} that receives tokens from another chain's
+ * {ITeleporterTokenBridge} instance, and represents the received tokens with an ERC20 token
+ * on this destination chain.
+ */
+contract ERC20Destination is IERC20Bridge, TeleporterTokenDestination, ERC20 {
+    using SafeERC20 for IERC20;
+
+    uint8 private immutable _decimals;
+
+    /**
+     * @notice Initializes this destination token bridge instance to receive
+     * tokens from the specified source chain and token bridge instance.
+     */
+    constructor(
+        address teleporterRegistryAddress,
+        address teleporterManager,
+        bytes32 sourceBlockchainID,
+        address tokenSourceAddress,
+        string memory tokenName,
+        string memory tokenSymbol,
+        uint8 tokenDecimals
+    )
+        TeleporterTokenDestination(
+            teleporterRegistryAddress,
+            teleporterManager,
+            sourceBlockchainID,
+            tokenSourceAddress,
+            address(this)
+        )
+        ERC20(tokenName, tokenSymbol)
+    {
+        _decimals = tokenDecimals;
+    }
+
+    /**
+     * @notice For transfers to an `input.destinationBlockchainID` that is not the `sourceBlockchainID`,
+     * a multihop transfer is performed, where the tokens are sent back to the token source chain
+     * first to check for bridge balance, and then forwarded to the final destination chain.
+     *
+     * @dev See {IERC20Bridge-send}
+     */
+    function send(SendTokensInput calldata input, uint256 amount) external {
+        _send(input, amount);
+    }
+
+    /**
+     * @dev See {IERC20-decimals}
+     */
+    function decimals() public view virtual override returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {TeleportTokenDestination-_deposit}
+     */
+    function _deposit(uint256 amount) internal virtual override returns (uint256) {
+        // TODO: can copy logic from SafeERC20TransferFrom.safeTransferFrom directly
+        // figure out if has gas savings.
+        return SafeERC20TransferFrom.safeTransferFrom(this, amount);
+    }
+
+    /**
+     * @dev See {TeleportTokenDestination-_withdraw}
+     */
+    function _withdraw(address recipient, uint256 amount) internal virtual override {
+        _mint(recipient, amount);
+    }
+
+    /**
+     * @dev See {TeleportTokenDestination-_burn}
+     *
+     * Calls {ERC20-_burn} to burn tokens from this contract.
+     */
+    function _burn(uint256 amount) internal virtual override {
+        _burn(address(this), amount);
+    }
+}

--- a/contracts/src/ERC20Source.sol
+++ b/contracts/src/ERC20Source.sol
@@ -1,0 +1,66 @@
+// (c) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.18;
+
+import {TeleporterTokenSource} from "./TeleporterTokenSource.sol";
+import {IERC20Bridge} from "./interfaces/IERC20Bridge.sol";
+import {SafeERC20TransferFrom} from "@teleporter/SafeERC20TransferFrom.sol";
+import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/utils/SafeERC20.sol";
+import {SendTokensInput} from "./interfaces/ITeleporterTokenBridge.sol";
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+
+/**
+ * @title ERC20Source
+ * @notice This contract is an {IERC20Bridge} that sends ERC20 tokens to another chain's
+ * {ITeleporterTokenBridge} instance, and gets represented by the tokens of that destination
+ * token bridge instance.
+ */
+contract ERC20Source is IERC20Bridge, TeleporterTokenSource {
+    using SafeERC20 for IERC20;
+
+    /// @notice The ERC20 token this source contract bridges to destination instances.
+    IERC20 public immutable token;
+
+    /**
+     * @notice Initializes this source token bridge instance to send
+     * tokens to the specified destination chain and token bridge instance.
+     *
+     * Teleporter fees are paid by the same token that is being bridged.
+     */
+    constructor(
+        address teleporterRegistryAddress,
+        address teleporterManager,
+        address tokenAddress
+    ) TeleporterTokenSource(teleporterRegistryAddress, teleporterManager, tokenAddress) {
+        token = IERC20(tokenAddress);
+    }
+
+    /**
+     * @dev See {IERC20Bridge-send}
+     */
+    function send(SendTokensInput calldata input, uint256 amount) external {
+        _send(input, amount);
+    }
+
+    /**
+     * @dev See {TeleportTokenSource-_deposit}
+     */
+    function _deposit(uint256 amount) internal virtual override returns (uint256) {
+        return SafeERC20TransferFrom.safeTransferFrom(token, amount);
+    }
+
+    /**
+     * @dev See {TeleportTokenSource-_withdraw}
+     */
+    function _withdraw(address recipient, uint256 amount) internal virtual override {
+        token.safeTransfer(recipient, amount);
+    }
+}

--- a/contracts/test/TeleporterTokenDestinationTests.t.sol
+++ b/contracts/test/TeleporterTokenDestinationTests.t.sol
@@ -43,6 +43,10 @@ contract ExampleDestinationApp is TeleporterTokenDestination {
     function _withdraw(address recipient, uint256 amount) internal virtual override {}
 
     function _burn(uint256 amount) internal virtual override {}
+
+    function _deposit(uint256 amount) internal virtual override returns (uint256) {
+        return amount;
+    }
 }
 
 contract TeleporterTokenDestinationTest is Test {

--- a/contracts/test/TeleporterTokenSourceTests.t.sol
+++ b/contracts/test/TeleporterTokenSourceTests.t.sol
@@ -13,7 +13,7 @@ import {
     TeleporterMessageInput,
     TeleporterFeeInfo
 } from "@teleporter/ITeleporterMessenger.sol";
-import {UnitTestMockERC20} from "../lib/teleporter/contracts/src/Mocks/UnitTestMockERC20.sol";
+import {ExampleERC20} from "../lib/teleporter/contracts/src/Mocks/ExampleERC20.sol";
 import {
     ITeleporterTokenBridge, SendTokensInput
 } from "../src/interfaces/ITeleporterTokenBridge.sol";
@@ -54,12 +54,12 @@ contract TeleporterTokenSourceTest is Test {
         bytes32(hex"1111111111111111111111111111111111111111111111111111111111111111");
 
     ExampleSourceApp public app;
-    UnitTestMockERC20 public mockERC20;
+    ExampleERC20 public mockERC20;
 
     event SendTokens(bytes32 indexed teleporterMessageID, address indexed sender, uint256 amount);
 
     function setUp() public virtual {
-        mockERC20 = new UnitTestMockERC20();
+        mockERC20 = new ExampleERC20();
         vm.mockCall(
             WARP_PRECOMPILE_ADDRESS,
             abi.encodeWithSelector(IWarpMessenger.getBlockchainID.selector),

--- a/contracts/test/TeleporterTokenSourceTests.t.sol
+++ b/contracts/test/TeleporterTokenSourceTests.t.sol
@@ -31,6 +31,10 @@ contract ExampleSourceApp is TeleporterTokenSource {
     }
 
     function _withdraw(address recipient, uint256 amount) internal virtual override {}
+
+    function _deposit(uint256 amount) internal virtual override returns (uint256) {
+        return amount;
+    }
 }
 
 contract TeleporterTokenSourceTest is Test {


### PR DESCRIPTION
## Why this should be merged
ERC20 token bridge source and destination contracts, fixes #5 

## How this works
Inherits `TeleporterTokenSource` and `TeleporterTokenDestination` to make two token bridge contracts.

ERC20Source takes in an existing ERC20 to be bridged, and uses the same ERC20 for Teleporter fees. ERC20Destination is an ERC20 that has built in cross-chain messaging with Teleporter, and is also by default compatible with other `TeleporterTokenBridge` instances.

Adds a `_deposit()` function that needs to be implemented by token bridges, which deposits the funds sent from caller to the bridge instance, either to be locked for source, or burned on destination.

## How this was tested
TODO

## How is this documented
TODO update README
