### PR TITLE
Unit tests for TeleporterTokenSource

### DIFF
--- a/contracts/src/TeleporterTokenDestination.sol
+++ b/contracts/src/TeleporterTokenDestination.sol
@@ -7,7 +7,7 @@ pragma solidity 0.8.18;
 
 import {TeleporterMessageInput, TeleporterFeeInfo} from "@teleporter/ITeleporterMessenger.sol";
 import {TeleporterOwnerUpgradeable} from "@teleporter/upgrades/TeleporterOwnerUpgradeable.sol";
-import {ITeleporterTokenBridge} from "./interfaces/ITeleporterTokenBridge.sol";
+import {ITeleporterTokenBridge, SendTokensInput} from "./interfaces/ITeleporterTokenBridge.sol";
 import {IWarpMessenger} from
     "@avalabs/subnet-evm-contracts@1.2.0/contracts/interfaces/IWarpMessenger.sol";
 import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/IERC20.sol";

--- a/contracts/src/TeleporterTokenSource.sol
+++ b/contracts/src/TeleporterTokenSource.sol
@@ -7,7 +7,7 @@ pragma solidity 0.8.18;
 
 import {TeleporterMessageInput, TeleporterFeeInfo} from "@teleporter/ITeleporterMessenger.sol";
 import {TeleporterOwnerUpgradeable} from "@teleporter/upgrades/TeleporterOwnerUpgradeable.sol";
-import {ITeleporterTokenBridge} from "./interfaces/ITeleporterTokenBridge.sol";
+import {ITeleporterTokenBridge, SendTokensInput} from "./interfaces/ITeleporterTokenBridge.sol";
 import {IWarpMessenger} from
     "@avalabs/subnet-evm-contracts@1.2.0/contracts/interfaces/IWarpMessenger.sol";
 import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/IERC20.sol";
@@ -116,7 +116,7 @@ abstract contract TeleporterTokenSource is ITeleporterTokenBridge, TeleporterOwn
 
         // Check that bridge instance returning has sufficient amount in balance
         uint256 senderBalance = bridgedBalances[sourceBlockchainID][originSenderAddress];
-        require(senderBalance >= amount, "TeleporterTokenSource: insufficient balance to unwrap");
+        require(senderBalance >= amount, "TeleporterTokenSource: insufficient bridge balance");
 
         // Decrement the bridge balance by the unwrap amount
         bridgedBalances[sourceBlockchainID][originSenderAddress] = senderBalance - amount;

--- a/contracts/src/interfaces/IERC20Bridge.sol
+++ b/contracts/src/interfaces/IERC20Bridge.sol
@@ -5,7 +5,7 @@
 
 pragma solidity 0.8.18;
 
-import {ITeleporterTokenBridge} from "./ITeleporterTokenBridge.sol";
+import {ITeleporterTokenBridge, SendTokensInput} from "./ITeleporterTokenBridge.sol";
 
 /**
  * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.

--- a/contracts/src/interfaces/INativeTokenBridge.sol
+++ b/contracts/src/interfaces/INativeTokenBridge.sol
@@ -5,7 +5,7 @@
 
 pragma solidity 0.8.18;
 
-import {ITeleporterTokenBridge} from "./ITeleporterTokenBridge.sol";
+import {ITeleporterTokenBridge, SendTokensInput} from "./ITeleporterTokenBridge.sol";
 
 /**
  * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.

--- a/contracts/src/interfaces/ITeleporterTokenBridge.sol
+++ b/contracts/src/interfaces/ITeleporterTokenBridge.sol
@@ -13,27 +13,27 @@ import {ITeleporterReceiver} from "@teleporter/ITeleporterReceiver.sol";
  */
 
 /**
+ * @dev Parameters for delivery of tokens to another chain and destination recipient.
+ * @param destinationBlockchainID blockchainID of the destination
+ * @param destinationBridgeAddress address of the destination token bridge instance
+ * @param recipient address of the recipient on the destination chain
+ * @param primaryFee amount of tokens to pay for Teleporter fee on the source chain
+ * @param secondaryFee amount of tokens to pay for Teleporter fee if a multihop is needed.
+ * @param allowedRelayerAddresses addresses of relayers allowed to send the message
+ */
+struct SendTokensInput {
+    bytes32 destinationBlockchainID;
+    address destinationBridgeAddress;
+    address recipient;
+    uint256 primaryFee;
+    uint256 secondaryFee;
+    address[] allowedRelayerAddresses;
+}
+
+/**
  * @dev Interface for a Teleporter token bridge that sends tokens to another chain.
  */
 interface ITeleporterTokenBridge is ITeleporterReceiver {
-    /**
-     * @dev Parameters for delivery of tokens to another chain and destination recipient.
-     * @param destinationBlockchainID blockchainID of the destination
-     * @param destinationBridgeAddress address of the destination token bridge instance
-     * @param recipient address of the recipient on the destination chain
-     * @param primaryFee amount of tokens to pay for Teleporter fee on the source chain
-     * @param secondaryFee amount of tokens to pay for Teleporter fee if a multihop is needed.
-     * @param allowedRelayerAddresses addresses of relayers allowed to send the message
-     */
-    struct SendTokensInput {
-        bytes32 destinationBlockchainID;
-        address destinationBridgeAddress;
-        address recipient;
-        uint256 primaryFee;
-        uint256 secondaryFee;
-        address[] allowedRelayerAddresses;
-    }
-
     /**
      * @dev Emitted when tokens are sent to another chain.
      * TODO: might want to add SendTokensInput as a parameter

--- a/contracts/test/TeleporterTokenSourceTests.t.sol
+++ b/contracts/test/TeleporterTokenSourceTests.t.sol
@@ -1,0 +1,46 @@
+// (c) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: Ecosystem
+
+pragma solidity 0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {TeleporterTokenSource, IWarpMessenger} from "../src/TeleporterTokenSource.sol";
+
+contract ExampleSourceApp is TeleporterTokenSource {
+    constructor(
+        address teleporterRegistryAddress,
+        address teleporterManager,
+        address feeTokenAddress
+    ) TeleporterTokenSource(teleporterRegistryAddress, teleporterManager, feeTokenAddress) {}
+
+    function _withdraw(address recipient, uint256 amount) internal virtual override {}
+}
+
+contract TeleporterTokenSourceTest is Test {
+    bytes32 public constant DEFAULT_SOURCE_BLOCKCHAIN_ID =
+        bytes32(hex"abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+    bytes32 public constant DEFAULT_DESTINATION_BLOCKCHAIN_ID =
+        bytes32(hex"1234567812345678123456781234567812345678123456781234567812345678");
+    address public constant DEFAULT_DESTINATION_ADDRESS = 0xd54e3E251b9b0EEd3ed70A858e927bbC2659587d;
+    address public constant WARP_PRECOMPILE_ADDRESS = 0x0200000000000000000000000000000000000005;
+
+    ExampleSourceApp public app;
+
+    function setUp() public virtual {
+        vm.mockCall(
+            WARP_PRECOMPILE_ADDRESS,
+            abi.encodeWithSelector(IWarpMessenger.getBlockchainID.selector),
+            abi.encode(DEFAULT_SOURCE_BLOCKCHAIN_ID)
+        );
+
+        vm.deployContract(
+            "ExampleSourceApp",
+            "ExampleSourceApp(address,address,address)",
+            address(teleporterRegistry),
+            address(this),
+            address(feeToken)
+        );
+    }
+}

--- a/contracts/test/TeleporterTokenSourceTests.t.sol
+++ b/contracts/test/TeleporterTokenSourceTests.t.sol
@@ -86,78 +86,36 @@ contract TeleporterTokenSourceTest is Test {
      */
 
     function testSendToSameChain() public {
+        SendTokensInput memory input = _createDefaultSendTokensInput();
+        input.destinationBlockchainID = DEFAULT_SOURCE_BLOCKCHAIN_ID;
         vm.expectRevert(_formatTokenSourceErrorMessage("cannot bridge to same chain"));
-        app.send(
-            SendTokensInput({
-                destinationBlockchainID: DEFAULT_SOURCE_BLOCKCHAIN_ID,
-                destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
-                recipient: DEFAULT_RECIPIENT_ADDRESS,
-                primaryFee: 0,
-                secondaryFee: 0,
-                allowedRelayerAddresses: new address[](0)
-            }),
-            0
-        );
+        app.send(input, 0);
     }
 
     function testZeroDestinationBridge() public {
+        SendTokensInput memory input = _createDefaultSendTokensInput();
+        input.destinationBridgeAddress = address(0);
         vm.expectRevert(_formatTokenSourceErrorMessage("zero destination bridge address"));
-        app.send(
-            SendTokensInput({
-                destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-                destinationBridgeAddress: address(0),
-                recipient: DEFAULT_RECIPIENT_ADDRESS,
-                primaryFee: 0,
-                secondaryFee: 0,
-                allowedRelayerAddresses: new address[](0)
-            }),
-            0
-        );
+        app.send(input, 0);
     }
 
     function testZeroRecipient() public {
+        SendTokensInput memory input = _createDefaultSendTokensInput();
+        input.recipient = address(0);
         vm.expectRevert(_formatTokenSourceErrorMessage("zero recipient address"));
-        app.send(
-            SendTokensInput({
-                destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-                destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
-                recipient: address(0),
-                primaryFee: 0,
-                secondaryFee: 0,
-                allowedRelayerAddresses: new address[](0)
-            }),
-            0
-        );
+        app.send(input, 0);
     }
 
     function testZeroSendAmount() public {
         vm.expectRevert(_formatTokenSourceErrorMessage("zero send amount"));
-        app.send(
-            SendTokensInput({
-                destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-                destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
-                recipient: DEFAULT_RECIPIENT_ADDRESS,
-                primaryFee: 0,
-                secondaryFee: 0,
-                allowedRelayerAddresses: new address[](0)
-            }),
-            0
-        );
+        app.send(_createDefaultSendTokensInput(), 0);
     }
 
     function testInsufficientAmountToCoverFees() public {
+        SendTokensInput memory input = _createDefaultSendTokensInput();
+        input.primaryFee = 1;
         vm.expectRevert(_formatTokenSourceErrorMessage("insufficient amount to cover fees"));
-        app.send(
-            SendTokensInput({
-                destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-                destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
-                recipient: DEFAULT_RECIPIENT_ADDRESS,
-                primaryFee: 1,
-                secondaryFee: 0,
-                allowedRelayerAddresses: new address[](0)
-            }),
-            1
-        );
+        app.send(input, input.primaryFee);
     }
 
     function testSendWithFees() public {
@@ -362,6 +320,17 @@ contract TeleporterTokenSourceTest is Test {
             abi.encodeWithSelector(TeleporterRegistry.getLatestTeleporter.selector),
             abi.encode(ITeleporterMessenger(MOCK_TELEPORTER_MESSENGER_ADDRESS))
         );
+    }
+
+    function _createDefaultSendTokensInput() internal pure returns (SendTokensInput memory) {
+        return SendTokensInput({
+            destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
+            destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
+            recipient: DEFAULT_RECIPIENT_ADDRESS,
+            primaryFee: 0,
+            secondaryFee: 0,
+            allowedRelayerAddresses: new address[](0)
+        });
     }
 
     function _formatTokenSourceErrorMessage(string memory errorMessage)

--- a/contracts/test/TeleporterTokenSourceTests.t.sol
+++ b/contracts/test/TeleporterTokenSourceTests.t.sol
@@ -7,6 +7,17 @@ pragma solidity 0.8.18;
 
 import {Test} from "forge-std/Test.sol";
 import {TeleporterTokenSource, IWarpMessenger} from "../src/TeleporterTokenSource.sol";
+import {TeleporterRegistry} from "@teleporter/upgrades/TeleporterRegistry.sol";
+import {
+    ITeleporterMessenger,
+    TeleporterMessageInput,
+    TeleporterFeeInfo
+} from "@teleporter/ITeleporterMessenger.sol";
+import {UnitTestMockERC20} from "../lib/teleporter/contracts/src/Mocks/UnitTestMockERC20.sol";
+import {
+    ITeleporterTokenBridge, SendTokensInput
+} from "../src/interfaces/ITeleporterTokenBridge.sol";
+import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/IERC20.sol";
 
 contract ExampleSourceApp is TeleporterTokenSource {
     constructor(
@@ -14,6 +25,10 @@ contract ExampleSourceApp is TeleporterTokenSource {
         address teleporterManager,
         address feeTokenAddress
     ) TeleporterTokenSource(teleporterRegistryAddress, teleporterManager, feeTokenAddress) {}
+
+    function send(SendTokensInput calldata input, uint256 amount) external {
+        _send(input, amount);
+    }
 
     function _withdraw(address recipient, uint256 amount) internal virtual override {}
 }
@@ -24,23 +39,299 @@ contract TeleporterTokenSourceTest is Test {
     bytes32 public constant DEFAULT_DESTINATION_BLOCKCHAIN_ID =
         bytes32(hex"1234567812345678123456781234567812345678123456781234567812345678");
     address public constant DEFAULT_DESTINATION_ADDRESS = 0xd54e3E251b9b0EEd3ed70A858e927bbC2659587d;
+    address public constant DEFAULT_RECIPIENT_ADDRESS = 0xABCDabcdABcDabcDaBCDAbcdABcdAbCdABcDABCd;
     address public constant WARP_PRECOMPILE_ADDRESS = 0x0200000000000000000000000000000000000005;
 
+    address public constant MOCK_TELEPORTER_MESSENGER_ADDRESS =
+        0x644E5b7c5D4Bc8073732CEa72c66e0BB90dFC00f;
+    address public constant MOCK_TELEPORTER_REGISTRY_ADDRESS =
+        0xf9FA4a0c696b659328DDaaBCB46Ae4eBFC9e68e4;
+    bytes32 internal constant _MOCK_MESSAGE_ID =
+        bytes32(hex"1111111111111111111111111111111111111111111111111111111111111111");
+
     ExampleSourceApp public app;
+    UnitTestMockERC20 public mockERC20;
+
+    event SendTokens(bytes32 indexed teleporterMessageID, address indexed sender, uint256 amount);
 
     function setUp() public virtual {
+        mockERC20 = new UnitTestMockERC20();
         vm.mockCall(
             WARP_PRECOMPILE_ADDRESS,
             abi.encodeWithSelector(IWarpMessenger.getBlockchainID.selector),
             abi.encode(DEFAULT_SOURCE_BLOCKCHAIN_ID)
         );
 
-        vm.deployContract(
-            "ExampleSourceApp",
-            "ExampleSourceApp(address,address,address)",
-            address(teleporterRegistry),
-            address(this),
-            address(feeToken)
+        vm.expectCall(
+            WARP_PRECOMPILE_ADDRESS, abi.encodeWithSelector(IWarpMessenger.getBlockchainID.selector)
         );
+
+        _initMockTeleporterRegistry();
+
+        vm.expectCall(
+            MOCK_TELEPORTER_REGISTRY_ADDRESS,
+            abi.encodeWithSelector(
+                TeleporterRegistry(MOCK_TELEPORTER_REGISTRY_ADDRESS).latestVersion.selector
+            )
+        );
+
+        app = new ExampleSourceApp(
+            MOCK_TELEPORTER_REGISTRY_ADDRESS,
+             address(this),
+              address(mockERC20));
+    }
+
+    /**
+     * Send tokens unit tests
+     */
+
+    function testSendToSameChain() public {
+        vm.expectRevert(_formatTokenSourceErrorMessage("cannot bridge to same chain"));
+        app.send(
+            SendTokensInput({
+                destinationBlockchainID: DEFAULT_SOURCE_BLOCKCHAIN_ID,
+                destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
+                recipient: DEFAULT_RECIPIENT_ADDRESS,
+                primaryFee: 0,
+                secondaryFee: 0,
+                allowedRelayerAddresses: new address[](0)
+            }),
+            0
+        );
+    }
+
+    function testZeroDestinationBridge() public {
+        vm.expectRevert(_formatTokenSourceErrorMessage("zero destination bridge address"));
+        app.send(
+            SendTokensInput({
+                destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
+                destinationBridgeAddress: address(0),
+                recipient: DEFAULT_RECIPIENT_ADDRESS,
+                primaryFee: 0,
+                secondaryFee: 0,
+                allowedRelayerAddresses: new address[](0)
+            }),
+            0
+        );
+    }
+
+    function testZeroRecipient() public {
+        vm.expectRevert(_formatTokenSourceErrorMessage("zero recipient address"));
+        app.send(
+            SendTokensInput({
+                destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
+                destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
+                recipient: address(0),
+                primaryFee: 0,
+                secondaryFee: 0,
+                allowedRelayerAddresses: new address[](0)
+            }),
+            0
+        );
+    }
+
+    function testZeroSendAmount() public {
+        vm.expectRevert(_formatTokenSourceErrorMessage("zero send amount"));
+        app.send(
+            SendTokensInput({
+                destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
+                destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
+                recipient: DEFAULT_RECIPIENT_ADDRESS,
+                primaryFee: 0,
+                secondaryFee: 0,
+                allowedRelayerAddresses: new address[](0)
+            }),
+            0
+        );
+    }
+
+    function testInsufficientAmountToCoverFees() public {
+        vm.expectRevert(_formatTokenSourceErrorMessage("insufficient amount to cover fees"));
+        app.send(
+            SendTokensInput({
+                destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
+                destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
+                recipient: DEFAULT_RECIPIENT_ADDRESS,
+                primaryFee: 1,
+                secondaryFee: 0,
+                allowedRelayerAddresses: new address[](0)
+            }),
+            1
+        );
+    }
+
+    function testSendWithFees() public {
+        uint256 amount = 2;
+        uint256 primaryFee = 1;
+        _sendSuccess(amount, primaryFee);
+    }
+
+    function testSendNoFees() public {
+        uint256 amount = 2;
+        uint256 primaryFee = 0;
+        _sendSuccess(amount, primaryFee);
+    }
+
+    /**
+     * Receive tokens unit tests
+     */
+
+    function testInsufficientBridgeBalance() public {
+        vm.expectRevert(_formatTokenSourceErrorMessage("insufficient bridge balance"));
+        vm.prank(MOCK_TELEPORTER_MESSENGER_ADDRESS);
+        app.receiveTeleporterMessage(
+            DEFAULT_DESTINATION_BLOCKCHAIN_ID,
+            DEFAULT_DESTINATION_ADDRESS,
+            abi.encode(
+                SendTokensInput({
+                    destinationBlockchainID: DEFAULT_SOURCE_BLOCKCHAIN_ID,
+                    destinationBridgeAddress: address(this),
+                    recipient: DEFAULT_RECIPIENT_ADDRESS,
+                    primaryFee: 0,
+                    secondaryFee: 0,
+                    allowedRelayerAddresses: new address[](0)
+                }),
+                1
+            )
+        );
+    }
+
+    function testInvalidDestinationBridgeAddress() public {
+        // First send to destination blockchain to increase the bridge balance
+        _sendSuccess(2, 0);
+        vm.expectRevert(_formatTokenSourceErrorMessage("invalid bridge address"));
+        vm.prank(MOCK_TELEPORTER_MESSENGER_ADDRESS);
+        app.receiveTeleporterMessage(
+            DEFAULT_DESTINATION_BLOCKCHAIN_ID,
+            DEFAULT_DESTINATION_ADDRESS,
+            abi.encode(
+                SendTokensInput({
+                    destinationBlockchainID: DEFAULT_SOURCE_BLOCKCHAIN_ID,
+                    destinationBridgeAddress: address(0),
+                    recipient: DEFAULT_RECIPIENT_ADDRESS,
+                    primaryFee: 0,
+                    secondaryFee: 0,
+                    allowedRelayerAddresses: new address[](0)
+                }),
+                1
+            )
+        );
+    }
+
+    function testMultiHopTransfer() public {
+        // First send to destination blockchain to increase the bridge balance
+        _sendSuccess(2, 0);
+
+        uint256 amount = 1;
+        uint256 feeAmount = 0;
+        uint256 bridgedAmount = amount - feeAmount;
+        SendTokensInput memory input = SendTokensInput({
+            destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
+            destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
+            recipient: DEFAULT_RECIPIENT_ADDRESS,
+            primaryFee: feeAmount,
+            secondaryFee: 0,
+            allowedRelayerAddresses: new address[](0)
+        });
+
+        _checkExpectedTeleporterCalls(input, bridgedAmount);
+
+        vm.expectEmit(true, true, true, true, address(app));
+        emit SendTokens(_MOCK_MESSAGE_ID, address(MOCK_TELEPORTER_MESSENGER_ADDRESS), bridgedAmount);
+
+        // Expect to call {TeleporterTokenSource-_send} for a multihop transfer
+        vm.prank(MOCK_TELEPORTER_MESSENGER_ADDRESS);
+        app.receiveTeleporterMessage(
+            DEFAULT_DESTINATION_BLOCKCHAIN_ID, DEFAULT_DESTINATION_ADDRESS, abi.encode(input, 1)
+        );
+    }
+
+    function _sendSuccess(uint256 amount, uint256 feeAmount) internal {
+        uint256 bridgedAmount = amount - feeAmount;
+        SendTokensInput memory input = SendTokensInput({
+            destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
+            destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
+            recipient: DEFAULT_RECIPIENT_ADDRESS,
+            primaryFee: feeAmount,
+            secondaryFee: 0,
+            allowedRelayerAddresses: new address[](0)
+        });
+
+        _checkExpectedTeleporterCalls(input, bridgedAmount);
+
+        vm.expectEmit(true, true, true, true, address(app));
+        emit SendTokens(_MOCK_MESSAGE_ID, address(this), bridgedAmount);
+        app.send(input, amount);
+    }
+
+    function _checkExpectedTeleporterCalls(
+        SendTokensInput memory input,
+        uint256 bridgeAmount
+    ) internal {
+        TeleporterMessageInput memory expectedMessageInput = TeleporterMessageInput({
+            destinationBlockchainID: input.destinationBlockchainID,
+            destinationAddress: input.destinationBridgeAddress,
+            feeInfo: TeleporterFeeInfo({feeTokenAddress: address(mockERC20), amount: input.primaryFee}),
+            requiredGasLimit: 0,
+            allowedRelayerAddresses: input.allowedRelayerAddresses,
+            message: abi.encode(DEFAULT_RECIPIENT_ADDRESS, bridgeAmount)
+        });
+
+        if (input.primaryFee > 0) {
+            vm.expectCall(
+                address(mockERC20),
+                abi.encodeCall(
+                    IERC20.allowance, (address(app), address(MOCK_TELEPORTER_MESSENGER_ADDRESS))
+                )
+            );
+        }
+        vm.mockCall(
+            MOCK_TELEPORTER_MESSENGER_ADDRESS,
+            abi.encodeCall(ITeleporterMessenger.sendCrossChainMessage, (expectedMessageInput)),
+            abi.encode(_MOCK_MESSAGE_ID)
+        );
+        vm.expectCall(
+            MOCK_TELEPORTER_MESSENGER_ADDRESS,
+            abi.encodeCall(ITeleporterMessenger.sendCrossChainMessage, (expectedMessageInput))
+        );
+    }
+
+    function _initMockTeleporterRegistry() internal {
+        vm.mockCall(
+            MOCK_TELEPORTER_REGISTRY_ADDRESS,
+            abi.encodeWithSelector(
+                TeleporterRegistry(MOCK_TELEPORTER_REGISTRY_ADDRESS).latestVersion.selector
+            ),
+            abi.encode(1)
+        );
+
+        vm.mockCall(
+            MOCK_TELEPORTER_REGISTRY_ADDRESS,
+            abi.encodeWithSelector(
+                TeleporterRegistry.getVersionFromAddress.selector,
+                (MOCK_TELEPORTER_MESSENGER_ADDRESS)
+            ),
+            abi.encode(1)
+        );
+
+        vm.mockCall(
+            MOCK_TELEPORTER_REGISTRY_ADDRESS,
+            abi.encodeWithSelector(TeleporterRegistry.getAddressFromVersion.selector, (1)),
+            abi.encode(MOCK_TELEPORTER_MESSENGER_ADDRESS)
+        );
+
+        vm.mockCall(
+            MOCK_TELEPORTER_REGISTRY_ADDRESS,
+            abi.encodeWithSelector(TeleporterRegistry.getLatestTeleporter.selector),
+            abi.encode(ITeleporterMessenger(MOCK_TELEPORTER_MESSENGER_ADDRESS))
+        );
+    }
+
+    function _formatTokenSourceErrorMessage(string memory errorMessage)
+        private
+        pure
+        returns (bytes memory)
+    {
+        return bytes(string.concat("TeleporterTokenSource: ", errorMessage));
     }
 }


### PR DESCRIPTION
## Why this should be merged
Fixes #8 

## How this works
- Unit tests for all send/receive token cases on `TeleporterTokenSource`
- Mocks the Teleporter registry and messenger
- 
## How this was tested
- send and receive base requirement checks
- with fee/no fee send and expected Teleporter calls
- multihop success and fail cases

## How is this documented
n/a
