### PR TITLE
Teleporter token destination unit tests

### DIFF
--- a/contracts/test/TeleporterTokenDestinationTests.t.sol
+++ b/contracts/test/TeleporterTokenDestinationTests.t.sol
@@ -6,7 +6,7 @@
 pragma solidity 0.8.18;
 
 import {Test} from "forge-std/Test.sol";
-import {TeleporterTokenSource, IWarpMessenger} from "../src/TeleporterTokenSource.sol";
+import {TeleporterTokenDestination, IWarpMessenger} from "../src/TeleporterTokenDestination.sol";
 import {TeleporterRegistry} from "@teleporter/upgrades/TeleporterRegistry.sol";
 import {
     ITeleporterMessenger,
@@ -19,26 +19,38 @@ import {
 } from "../src/interfaces/ITeleporterTokenBridge.sol";
 import {IERC20} from "@openzeppelin/contracts@4.8.1/token/ERC20/IERC20.sol";
 
-contract ExampleSourceApp is TeleporterTokenSource {
+contract ExampleDestinationApp is TeleporterTokenDestination {
     constructor(
         address teleporterRegistryAddress,
         address teleporterManager,
+        bytes32 sourceBlockchainID,
+        address tokenSourceAddress,
         address feeTokenAddress
-    ) TeleporterTokenSource(teleporterRegistryAddress, teleporterManager, feeTokenAddress) {}
+    )
+        TeleporterTokenDestination(
+            teleporterRegistryAddress,
+            teleporterManager,
+            sourceBlockchainID,
+            tokenSourceAddress,
+            feeTokenAddress
+        )
+    {}
 
     function send(SendTokensInput calldata input, uint256 amount) external {
         _send(input, amount);
     }
 
     function _withdraw(address recipient, uint256 amount) internal virtual override {}
+
+    function _burn(uint256 amount) internal virtual override {}
 }
 
-contract TeleporterTokenSourceTest is Test {
+contract TeleporterTokenDestinationTest is Test {
     bytes32 public constant DEFAULT_SOURCE_BLOCKCHAIN_ID =
         bytes32(hex"abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd");
     bytes32 public constant DEFAULT_DESTINATION_BLOCKCHAIN_ID =
         bytes32(hex"1234567812345678123456781234567812345678123456781234567812345678");
-    address public constant DEFAULT_DESTINATION_ADDRESS = 0xd54e3E251b9b0EEd3ed70A858e927bbC2659587d;
+    address public constant TOKEN_SOURCE_ADDRESS = 0xd54e3E251b9b0EEd3ed70A858e927bbC2659587d;
     address public constant DEFAULT_RECIPIENT_ADDRESS = 0xABCDabcdABcDabcDaBCDAbcdABcdAbCdABcDABCd;
     address public constant WARP_PRECOMPILE_ADDRESS = 0x0200000000000000000000000000000000000005;
 
@@ -49,7 +61,7 @@ contract TeleporterTokenSourceTest is Test {
     bytes32 internal constant _MOCK_MESSAGE_ID =
         bytes32(hex"1111111111111111111111111111111111111111111111111111111111111111");
 
-    ExampleSourceApp public app;
+    ExampleDestinationApp public app;
     UnitTestMockERC20 public mockERC20;
 
     event SendTokens(bytes32 indexed teleporterMessageID, address indexed sender, uint256 amount);
@@ -59,7 +71,7 @@ contract TeleporterTokenSourceTest is Test {
         vm.mockCall(
             WARP_PRECOMPILE_ADDRESS,
             abi.encodeWithSelector(IWarpMessenger.getBlockchainID.selector),
-            abi.encode(DEFAULT_SOURCE_BLOCKCHAIN_ID)
+            abi.encode(DEFAULT_DESTINATION_BLOCKCHAIN_ID)
         );
 
         vm.expectCall(
@@ -75,10 +87,12 @@ contract TeleporterTokenSourceTest is Test {
             )
         );
 
-        app = new ExampleSourceApp(
+        app = new ExampleDestinationApp(
             MOCK_TELEPORTER_REGISTRY_ADDRESS,
-             address(this),
-              address(mockERC20));
+            address(this),
+            DEFAULT_SOURCE_BLOCKCHAIN_ID,
+            TOKEN_SOURCE_ADDRESS,
+            address(mockERC20));
     }
 
     /**
@@ -87,34 +101,34 @@ contract TeleporterTokenSourceTest is Test {
 
     function testSendToSameChain() public {
         SendTokensInput memory input = _createDefaultSendTokensInput();
-        input.destinationBlockchainID = DEFAULT_SOURCE_BLOCKCHAIN_ID;
-        vm.expectRevert(_formatTokenSourceErrorMessage("cannot bridge to same chain"));
+        input.destinationBlockchainID = DEFAULT_DESTINATION_BLOCKCHAIN_ID;
+        vm.expectRevert(_formatTokenDestinationErrorMessage("cannot bridge to same chain"));
         app.send(input, 0);
     }
 
     function testZeroDestinationBridge() public {
         SendTokensInput memory input = _createDefaultSendTokensInput();
         input.destinationBridgeAddress = address(0);
-        vm.expectRevert(_formatTokenSourceErrorMessage("zero destination bridge address"));
+        vm.expectRevert(_formatTokenDestinationErrorMessage("zero destination bridge address"));
         app.send(input, 0);
     }
 
     function testZeroRecipient() public {
         SendTokensInput memory input = _createDefaultSendTokensInput();
         input.recipient = address(0);
-        vm.expectRevert(_formatTokenSourceErrorMessage("zero recipient address"));
+        vm.expectRevert(_formatTokenDestinationErrorMessage("zero recipient address"));
         app.send(input, 0);
     }
 
     function testZeroSendAmount() public {
-        vm.expectRevert(_formatTokenSourceErrorMessage("zero send amount"));
+        vm.expectRevert(_formatTokenDestinationErrorMessage("zero send amount"));
         app.send(_createDefaultSendTokensInput(), 0);
     }
 
     function testInsufficientAmountToCoverFees() public {
         SendTokensInput memory input = _createDefaultSendTokensInput();
         input.primaryFee = 1;
-        vm.expectRevert(_formatTokenSourceErrorMessage("insufficient amount to cover fees"));
+        vm.expectRevert(_formatTokenDestinationErrorMessage("insufficient amount to cover fees"));
         app.send(input, input.primaryFee);
     }
 
@@ -134,118 +148,25 @@ contract TeleporterTokenSourceTest is Test {
      * Receive tokens unit tests
      */
 
+    function testInvalidSourceChain() public {
+        vm.expectRevert(_formatTokenDestinationErrorMessage("invalid source chain"));
+        vm.prank(MOCK_TELEPORTER_MESSENGER_ADDRESS);
+        app.receiveTeleporterMessage(
+            DEFAULT_DESTINATION_BLOCKCHAIN_ID, TOKEN_SOURCE_ADDRESS, new bytes(0)
+        );
+    }
+
+    function testInvalidTokenSourceAddress() public {
+        vm.expectRevert(_formatTokenDestinationErrorMessage("invalid token source address"));
+        vm.prank(MOCK_TELEPORTER_MESSENGER_ADDRESS);
+        app.receiveTeleporterMessage(DEFAULT_SOURCE_BLOCKCHAIN_ID, address(0), new bytes(0));
+    }
+
     function testReceivedInvalidMessage() public {
         vm.expectRevert();
         vm.prank(MOCK_TELEPORTER_MESSENGER_ADDRESS);
         app.receiveTeleporterMessage(
-            DEFAULT_DESTINATION_BLOCKCHAIN_ID, DEFAULT_DESTINATION_ADDRESS, bytes("test")
-        );
-    }
-
-    function testInsufficientBridgeBalance() public {
-        vm.expectRevert(_formatTokenSourceErrorMessage("insufficient bridge balance"));
-        vm.prank(MOCK_TELEPORTER_MESSENGER_ADDRESS);
-        app.receiveTeleporterMessage(
-            DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-            DEFAULT_DESTINATION_ADDRESS,
-            abi.encode(
-                SendTokensInput({
-                    destinationBlockchainID: DEFAULT_SOURCE_BLOCKCHAIN_ID,
-                    destinationBridgeAddress: address(this),
-                    recipient: DEFAULT_RECIPIENT_ADDRESS,
-                    primaryFee: 0,
-                    secondaryFee: 0,
-                    allowedRelayerAddresses: new address[](0)
-                }),
-                1
-            )
-        );
-    }
-
-    function testInvalidDestinationBridgeAddress() public {
-        // First send to destination blockchain to increase the bridge balance
-        _sendSuccess(2, 0);
-        vm.expectRevert(_formatTokenSourceErrorMessage("invalid bridge address"));
-        vm.prank(MOCK_TELEPORTER_MESSENGER_ADDRESS);
-        app.receiveTeleporterMessage(
-            DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-            DEFAULT_DESTINATION_ADDRESS,
-            abi.encode(
-                SendTokensInput({
-                    destinationBlockchainID: DEFAULT_SOURCE_BLOCKCHAIN_ID,
-                    destinationBridgeAddress: address(0),
-                    recipient: DEFAULT_RECIPIENT_ADDRESS,
-                    primaryFee: 0,
-                    secondaryFee: 0,
-                    allowedRelayerAddresses: new address[](0)
-                }),
-                1
-            )
-        );
-    }
-
-    function testMultiHopTransfer() public {
-        // First send to destination blockchain to increase the bridge balance
-        uint256 amount = 2;
-        _sendSuccess(amount, 0);
-
-        uint256 feeAmount = 1;
-        uint256 bridgedAmount = amount - feeAmount;
-        SendTokensInput memory input = SendTokensInput({
-            destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-            destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
-            recipient: DEFAULT_RECIPIENT_ADDRESS,
-            primaryFee: feeAmount,
-            secondaryFee: 0,
-            allowedRelayerAddresses: new address[](0)
-        });
-
-        _checkExpectedTeleporterCalls(input, bridgedAmount);
-
-        vm.expectEmit(true, true, true, true, address(app));
-        emit SendTokens(_MOCK_MESSAGE_ID, address(MOCK_TELEPORTER_MESSENGER_ADDRESS), bridgedAmount);
-
-        // Expect to call {TeleporterTokenSource-_send} for a multihop transfer
-        vm.prank(MOCK_TELEPORTER_MESSENGER_ADDRESS);
-        app.receiveTeleporterMessage(
-            DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-            DEFAULT_DESTINATION_ADDRESS,
-            abi.encode(input, amount)
-        );
-    }
-
-    function testMultiHopTransferFails() public {
-        // First send to destination blockchain to increase the bridge balance
-        uint256 amount = 2;
-        _sendSuccess(amount, 0);
-        uint256 balanceBefore =
-            app.bridgedBalances(DEFAULT_DESTINATION_BLOCKCHAIN_ID, DEFAULT_DESTINATION_ADDRESS);
-        assertEq(balanceBefore, amount);
-
-        // Fail due to insufficient amount to cover fees
-        uint256 feeAmount = amount;
-        SendTokensInput memory input = SendTokensInput({
-            destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-            destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
-            recipient: DEFAULT_RECIPIENT_ADDRESS,
-            primaryFee: feeAmount,
-            secondaryFee: 0,
-            allowedRelayerAddresses: new address[](0)
-        });
-
-        vm.expectRevert(_formatTokenSourceErrorMessage("insufficient amount to cover fees"));
-        // Expect to call {TeleporterTokenSource-_send} for a multihop transfer
-        vm.prank(MOCK_TELEPORTER_MESSENGER_ADDRESS);
-        app.receiveTeleporterMessage(
-            DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-            DEFAULT_DESTINATION_ADDRESS,
-            abi.encode(input, amount)
-        );
-
-        // Make sure the bridge balance is still the same
-        assertEq(
-            app.bridgedBalances(DEFAULT_DESTINATION_BLOCKCHAIN_ID, DEFAULT_DESTINATION_ADDRESS),
-            balanceBefore
+            DEFAULT_SOURCE_BLOCKCHAIN_ID, TOKEN_SOURCE_ADDRESS, bytes("test")
         );
     }
 
@@ -266,12 +187,22 @@ contract TeleporterTokenSourceTest is Test {
         uint256 bridgeAmount
     ) internal {
         TeleporterMessageInput memory expectedMessageInput = TeleporterMessageInput({
-            destinationBlockchainID: input.destinationBlockchainID,
-            destinationAddress: input.destinationBridgeAddress,
+            destinationBlockchainID: DEFAULT_SOURCE_BLOCKCHAIN_ID,
+            destinationAddress: TOKEN_SOURCE_ADDRESS,
             feeInfo: TeleporterFeeInfo({feeTokenAddress: address(mockERC20), amount: input.primaryFee}),
             requiredGasLimit: 0,
             allowedRelayerAddresses: input.allowedRelayerAddresses,
-            message: abi.encode(DEFAULT_RECIPIENT_ADDRESS, bridgeAmount)
+            message: abi.encode(
+                SendTokensInput({
+                    destinationBlockchainID: input.destinationBlockchainID,
+                    destinationBridgeAddress: input.destinationBridgeAddress,
+                    recipient: input.recipient,
+                    primaryFee: input.secondaryFee,
+                    secondaryFee: 0,
+                    allowedRelayerAddresses: input.allowedRelayerAddresses
+                }),
+                bridgeAmount
+                )
         });
 
         if (input.primaryFee > 0) {
@@ -326,8 +257,8 @@ contract TeleporterTokenSourceTest is Test {
 
     function _createDefaultSendTokensInput() internal pure returns (SendTokensInput memory) {
         return SendTokensInput({
-            destinationBlockchainID: DEFAULT_DESTINATION_BLOCKCHAIN_ID,
-            destinationBridgeAddress: DEFAULT_DESTINATION_ADDRESS,
+            destinationBlockchainID: DEFAULT_SOURCE_BLOCKCHAIN_ID,
+            destinationBridgeAddress: TOKEN_SOURCE_ADDRESS,
             recipient: DEFAULT_RECIPIENT_ADDRESS,
             primaryFee: 0,
             secondaryFee: 0,
@@ -335,11 +266,11 @@ contract TeleporterTokenSourceTest is Test {
         });
     }
 
-    function _formatTokenSourceErrorMessage(string memory errorMessage)
+    function _formatTokenDestinationErrorMessage(string memory errorMessage)
         private
         pure
         returns (bytes memory)
     {
-        return bytes(string.concat("TeleporterTokenSource: ", errorMessage));
+        return bytes(string.concat("TeleporterTokenDestination: ", errorMessage));
     }
 }


### PR DESCRIPTION
## Why this should be merged
Fixes #9 

## How this works
Unit tests for sending/receiving with base contract of `TeleporterTokenDestination`

## How this was tested
CI, local

## How is this documented
n/a
