### PR TITLE
Added attestation workflow

### DIFF
--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -1,0 +1,9 @@
+name: Verify Commits with Yubikey Attestation
+
+on:
+  pull_request:
+
+jobs:
+  call-verify-commits-workflow:
+    uses: ava-labs/yubikey-attestation/.github/workflows/verify-attestation.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Why this should be merged

This PR adds the attestation workflow. This is configured to fail the job if attestation fails so if there's a concern there don't merge yet. We'll track all of these in SO-52. 

## How this works

For each new PR commits are checked against a database of attestation statements in the yubikey-attestation repository.

## How this was tested

Tested with SecOps repositories

## How is this documented

See the yubikey-attestation repository
