### PR TITLE
Bump Golang and Ubuntu

### DIFF
--- a/.github/workflows/abi_bindings_checker.yml
+++ b/.github/workflows/abi_bindings_checker.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   abi_binding:
     name: abi_binding
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout teleporter-token-bridge repository

--- a/.github/workflows/gomod_checker.yml
+++ b/.github/workflows/gomod_checker.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   gomod_check:
     name: Check go.mod
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   solhint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout teleporter
         uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
         run: ./scripts/lint.sh --sol-lint
 
   format-solidity:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - name: Checkout repository and submodules

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,7 +8,7 @@ on:
       - "dependabot/**"
 jobs:
   golang-snyk:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repositories and submodules
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   solidity-unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - name: Checkout repository and submodules
@@ -28,7 +28,7 @@ jobs:
           forge test -vvv
 
   go-unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repositories and submodules
@@ -53,7 +53,7 @@ jobs:
 
   e2e_tests:
     name: e2e_tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repositories and submodules
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/teleporter-token-bridge
 
-go 1.21.10
+go 1.21.11
 
 require (
 	github.com/ava-labs/avalanchego v1.11.1


### PR DESCRIPTION
## Why this should be merged
Bumps the Golang version used by the E2E tests and utilities, and bumps the Ubuntu version used to run the Github actions.